### PR TITLE
Does addition at /porter/<project_title>/issues/new/ work for you?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /static/fonts/
 static/js/
 delete.sql
+/mine.org

--- a/porter/project/urls.py
+++ b/porter/project/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url, include
-from porter.project.views import ProjectDetail, ProjectMembers, ProjectMemberRemove, ProjectMemberAdd, ProjectSettings, \
-    ProjectDelete, ProjectAssignRole, ProjectMilestones, ProjectMilestoneAdd
+from porter.project.views import ProjectDetail, ProjectMembers, ProjectMemberRemove,\
+    ProjectMemberAdd, ProjectSettings, ProjectDelete, ProjectAssignRole,\
+    ProjectMilestones, ProjectMilestoneAdd
 from porter.repository import urls as repository_urls
 from porter.issue import urls as issue_urls
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django=1.9.7
+django==1.9.7
 django-bootstrap3>=7.0.1
 django-bootstrap-pagination>=1.6.1
-Pillow=3.2.0
+Pillow==3.2.0


### PR DESCRIPTION
@BojanaZ, look at changes in `porter/issue/views.py`
This didn't worked for me because of `form.is_valid()` was `False`.
It seems that it was induced by difference between declared fields in
`IssueWithRepoForm.Meta` and fields contained in object returned by
`IssueForm(request.POST, auto_id=True)`.
Also, there are no `repository_title` in `/porter/<project_title>/issues/new/`.

Now I have another issue.

Project may have many repositories and just project title (gotten from
 url) is insufficient to determine which repository should receive this
 issue. Provided query on `Repository` may return many of them.

This looks to me like more logical issue - we can't determine which
repository should receive an issue having project title only, since
Repository to Project relationship is many to one.

Or I'm misunderstood something?
